### PR TITLE
fix: get release secret properly

### DIFF
--- a/.github/workflows/auto-tag-release-pr.yml
+++ b/.github/workflows/auto-tag-release-pr.yml
@@ -15,8 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Require tag push token
-        if: ${{ secrets.RELEASE_TAG_TOKEN == '' }}
+        env:
+          RELEASE_TAG_TOKEN: ${{ secrets.RELEASE_TAG_TOKEN }}
         run: |
+          if [ -n "$RELEASE_TAG_TOKEN" ]; then
+            exit 0
+          fi
           echo "Error: Missing RELEASE_TAG_TOKEN secret"
           echo "Add a fine-grained PAT or GitHub App token with Contents: Read and write access."
           exit 1


### PR DESCRIPTION
## What Changed

- Describe the user-visible change and why it was needed.

## Conventional Commit Checklist

- [x] Commit messages use conventional commit format: `type(scope): description`
- [ ] If this is a breaking change, I used `!` in the type (for example `feat!:`) or included `BREAKING CHANGE:` in the commit body
- [ ] If squash merge is used, the PR title is also in conventional commit format (it becomes the merge commit message)

## Validation

- [x] I ran relevant tests or checks locally
- [x] Docs were updated where needed
