### PR TITLE
fix(npm): add cli launcher shim

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -19,7 +19,7 @@
     "extensions"
   ],
   "bin": {
-    "ae": "bin/ae"
+    "ae": "scripts/run-ae.mjs"
   },
   "scripts": {
     "postinstall": "node scripts/download-binary.mjs"

--- a/npm/scripts/run-ae.mjs
+++ b/npm/scripts/run-ae.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+import { existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { spawn } from "child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(__dirname, "..");
+const executable = process.platform === "win32" ? "ae.exe" : "ae";
+const binaryPath = join(packageRoot, "bin", executable);
+
+if (!existsSync(binaryPath)) {
+  console.error("ae binary not found in package installation");
+  console.error("Try reinstalling: npm rebuild @shanepadgett/agent-extensions");
+  process.exit(1);
+}
+
+const child = spawn(binaryPath, process.argv.slice(2), { stdio: "inherit" });
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## Summary
- point npm bin to a stable launcher script instead of the downloaded binary path
- add a runtime launcher that executes the downloaded platform binary from npm's postinstall step
- remove npm publish warning about missing bin target so scoped package publish is clean