### PR TITLE
fix(release): fail when tag already exists

### DIFF
--- a/.github/workflows/auto-tag-release-pr.yml
+++ b/.github/workflows/auto-tag-release-pr.yml
@@ -38,8 +38,10 @@ jobs:
           TAG="v${VERSION}"
 
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping"
-            exit 0
+            echo "Error: Tag $TAG already exists"
+            echo "Auto-tag reruns do not retrigger release for existing tags."
+            echo "Delete and re-push the tag to trigger the Release workflow."
+            exit 1
           fi
 
           git tag "$TAG"


### PR DESCRIPTION
## Summary
- change auto-tag workflow to fail when the target release tag already exists
- surface explicit guidance that rerunning auto-tag does not retrigger release for existing tags
- provide the required recovery action (delete and re-push tag) directly in workflow logs